### PR TITLE
WIP: use dotnet-dojo docker image

### DIFF
--- a/Dojofile
+++ b/Dojofile
@@ -1,0 +1,2 @@
+DOJO_DRIVER=docker
+DOJO_DOCKER_IMAGE="kudulab/dotnet-dojo:alpine-3.1.1"

--- a/Dojofile.debian
+++ b/Dojofile.debian
@@ -1,0 +1,2 @@
+DOJO_DRIVER=docker
+DOJO_DOCKER_IMAGE="kudulab/dotnet-dojo:stretch-3.1.1"

--- a/Idefile
+++ b/Idefile
@@ -1,3 +1,0 @@
-IDE_DRIVER=docker
-# actually an image with paket and fake installed globally is also needed
-IDE_DOCKER_IMAGE="tomzo/dotnet-ide:alpine-2.0.0"

--- a/Idefile.debian
+++ b/Idefile.debian
@@ -1,3 +1,0 @@
-IDE_DRIVER=docker
-# actually an image with paket and fake installed globally is also needed
-IDE_DOCKER_IMAGE="tomzo/dotnet-ide:2.0.0"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pake and FAKE on dotnet core
+# Paket and FAKE on dotnet core
 
 This is a spike proving that it is possible to use paket, FAKE and build dotnet
 projects using a dotnet SDK without mono.
@@ -7,3 +7,9 @@ projects using a dotnet SDK without mono.
 
 Paket is a super early release. It generates invalid/inconvenient `.paket/Paket.Restore.targets`
  and I had to patch it so that bootstrapper is not executed ever and globally installed `paket` cli is used.
+
+## Usage
+Compile and run:
+```
+dojo ./build.sh
+``

--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+rm -rf ./paket-files
+
 paket restore
 git checkout .paket/Paket.Restore.targets
 fake run myscript.fsx


### PR DESCRIPTION
This repo is linked from https://github.com/kudulab/docker-dotnet-dojo as an example. Currently it uses dotnet-ide docker image (which is obsolete), let's make it use dotnet-dojo docker image.

This PR is WIP, because the `build.sh` does not work.